### PR TITLE
v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.2
+
+- `FutureOrIterableExtension` and `FutureIterableExtension`.
+  - Use suffix `Async` to avoid extension overwrite issues. 
+
 ## 1.2.1
 
 - New `FutureOrIterableExtension` and `FutureIterableExtension`.

--- a/lib/src/async_extension_base.dart
+++ b/lib/src/async_extension_base.dart
@@ -693,53 +693,53 @@ extension MapFutureExtension<K, V> on Map<FutureOr<K>, FutureOr<V>> {
 }
 
 extension FutureOrIterableExtension<T> on FutureOr<Iterable<T>> {
-  FutureOr<List<T>> toList({bool growable = true}) =>
+  FutureOr<List<T>> toListAsync({bool growable = true}) =>
       then((itr) => itr.toList());
 
-  FutureOr<Set<T>> toSet() => then((itr) => itr.toSet());
+  FutureOr<Set<T>> toSetAsync() => then((itr) => itr.toSet());
 
-  FutureOr<List<T>> get asList =>
+  FutureOr<List<T>> get asListAsync =>
       then((itr) => itr is List<T> ? itr : itr.toList());
 
-  FutureOr<int> get length => then((itr) => itr.length);
+  FutureOr<int> get lengthAsync => then((itr) => itr.length);
 
-  FutureOr<bool> get isEmpty => then((itr) => itr.isEmpty);
+  FutureOr<bool> get isEmptyAsync => then((itr) => itr.isEmpty);
 
-  FutureOr<bool> get isNotEmpty => then((itr) => itr.isNotEmpty);
+  FutureOr<bool> get isNotEmptyAsync => then((itr) => itr.isNotEmpty);
 
-  FutureOr<T> get first => then((itr) => itr.first);
+  FutureOr<T> get firstAsync => then((itr) => itr.first);
 
-  FutureOr<T?> get firstOrNull =>
+  FutureOr<T?> get firstOrNullAsync =>
       then((itr) => IterableExtensions(itr).firstOrNull);
 
-  FutureOr<T> get last => then((itr) => itr.last);
+  FutureOr<T> get lastAsync => then((itr) => itr.last);
 
-  FutureOr<T?> get lastOrNull =>
+  FutureOr<T?> get lastOrNullAsync =>
       then((itr) => IterableExtensions(itr).lastOrNull);
 }
 
 extension FutureIterableExtension<T> on Future<Iterable<T>> {
-  FutureOr<List<T>> toList({bool growable = true}) =>
+  FutureOr<List<T>> toListAsync({bool growable = true}) =>
       then((itr) => itr.toList());
 
-  Future<Set<T>> toSet() => then((itr) => itr.toSet());
+  Future<Set<T>> toSetAsync() => then((itr) => itr.toSet());
 
-  Future<List<T>> get asList =>
+  Future<List<T>> get asListAsync =>
       then((itr) => itr is List<T> ? itr : itr.toList());
 
-  Future<int> get length => then((itr) => itr.length);
+  Future<int> get lengthAsync => then((itr) => itr.length);
 
-  Future<bool> get isEmpty => then((itr) => itr.isEmpty);
+  Future<bool> get isEmptyAsync => then((itr) => itr.isEmpty);
 
-  Future<bool> get isNotEmpty => then((itr) => itr.isNotEmpty);
+  Future<bool> get isNotEmptyAsync => then((itr) => itr.isNotEmpty);
 
-  Future<T> get first => then((itr) => itr.first);
+  Future<T> get firstAsync => then((itr) => itr.first);
 
-  Future<T?> get firstOrNull => then((itr) => itr.firstOrNull);
+  Future<T?> get firstOrNullAsync => then((itr) => itr.firstOrNull);
 
-  Future<T> get last => then((itr) => itr.last);
+  Future<T> get lastAsync => then((itr) => itr.last);
 
-  Future<T?> get lastOrNull => then((itr) => itr.lastOrNull);
+  Future<T?> get lastOrNullAsync => then((itr) => itr.lastOrNull);
 }
 
 extension FutureOrIntExtension on FutureOr<int> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_extension
 description: Dart async extensions, to help usage of Future, FutureOr and async methods. Also allows performance improvements when using sync and async code.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/eneural-net/async_extension
 
 environment:

--- a/test/async_extension_test.dart
+++ b/test/async_extension_test.dart
@@ -557,16 +557,16 @@ void main() {
     test('Iterable', () {
       FutureOr<Iterable<int>> futureOrItr = [1, 2, 3];
 
-      expect(futureOrItr.toList(), equals([1, 2, 3]));
-      expect(futureOrItr.asList, equals([1, 2, 3]));
-      expect(futureOrItr.toSet(), equals({1, 2, 3}));
-      expect(futureOrItr.length, equals(3));
-      expect(futureOrItr.isEmpty, isFalse);
-      expect(futureOrItr.isNotEmpty, isTrue);
-      expect(futureOrItr.first, equals(1));
-      expect(futureOrItr.firstOrNull, equals(1));
-      expect(futureOrItr.last, equals(3));
-      expect(futureOrItr.lastOrNull, equals(3));
+      expect(futureOrItr.toListAsync(), equals([1, 2, 3]));
+      expect(futureOrItr.asListAsync, equals([1, 2, 3]));
+      expect(futureOrItr.toSetAsync(), equals({1, 2, 3}));
+      expect(futureOrItr.lengthAsync, equals(3));
+      expect(futureOrItr.isEmptyAsync, isFalse);
+      expect(futureOrItr.isNotEmptyAsync, isTrue);
+      expect(futureOrItr.firstAsync, equals(1));
+      expect(futureOrItr.firstOrNullAsync, equals(1));
+      expect(futureOrItr.lastAsync, equals(3));
+      expect(futureOrItr.lastOrNullAsync, equals(3));
     });
   });
 
@@ -574,16 +574,16 @@ void main() {
     test('Iterable', () async {
       Future<Iterable<int>> futureItr = Future.value([1, 2, 3]);
 
-      expect(await futureItr.toList(), equals([1, 2, 3]));
-      expect(await futureItr.asList, equals([1, 2, 3]));
-      expect(await futureItr.toSet(), equals({1, 2, 3}));
-      expect(await futureItr.length, equals(3));
-      expect(await futureItr.isEmpty, isFalse);
-      expect(await futureItr.isNotEmpty, isTrue);
-      expect(await futureItr.first, equals(1));
-      expect(await futureItr.firstOrNull, equals(1));
-      expect(await futureItr.last, equals(3));
-      expect(await futureItr.lastOrNull, equals(3));
+      expect(await futureItr.toListAsync(), equals([1, 2, 3]));
+      expect(await futureItr.asListAsync, equals([1, 2, 3]));
+      expect(await futureItr.toSetAsync(), equals({1, 2, 3}));
+      expect(await futureItr.lengthAsync, equals(3));
+      expect(await futureItr.isEmptyAsync, isFalse);
+      expect(await futureItr.isNotEmptyAsync, isTrue);
+      expect(await futureItr.firstAsync, equals(1));
+      expect(await futureItr.firstOrNullAsync, equals(1));
+      expect(await futureItr.lastAsync, equals(3));
+      expect(await futureItr.lastOrNullAsync, equals(3));
     });
   });
 


### PR DESCRIPTION
- `FutureOrIterableExtension` and `FutureIterableExtension`.
  - Use suffix `Async` to avoid extension overwrite issues.