### PR TITLE
v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.2.8
+
+- New `AsyncExtensionErrorLogger` and `defaultAsyncExtensionErrorLogger`:
+
+- New `FutureOnErrorExtension`:
+  - `logError`
+  - `onErrorReturn`
+  - `nullOnError`
+
+- `FutureNonNullOnErrorExtension`:
+  - `onComplete`
+
+- `FutureNullableOnErrorExtension`:
+  - `onComplete`
+  - `onCompleteNotNull`
+
 ## 1.2.7
 
 - `IterableFutureOrNullableExtension`:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_extension
 description: Dart async extensions, to help usage of Future, FutureOr and async methods. Also allows performance improvements when using sync and async code.
-version: 1.2.7
+version: 1.2.8
 homepage: https://github.com/eneural-net/async_extension
 
 environment:

--- a/test/async_extension_test.dart
+++ b/test/async_extension_test.dart
@@ -553,6 +553,214 @@ void main() {
     });
   });
 
+  group('FutureOnErrorExtension', () {
+    test('logError', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      await Future.microtask(() => 1).logError(errorLogger: logger);
+      expect(loggedErrors, isEmpty);
+
+      try {
+        await Future.microtask(() => throw StateError(''))
+            .logError(errorLogger: logger);
+      } catch (e) {
+        print(e);
+      }
+      expect(loggedErrors.length, equals(1));
+    });
+
+    test('onErrorReturn', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      expect(
+          await Future.microtask(() => 1)
+              .onErrorReturn(-1, errorLogger: logger),
+          equals(1));
+      expect(loggedErrors, isEmpty);
+
+      expect(
+          await Future<int>.microtask(() => throw StateError(''))
+              .onErrorReturn(-2, errorLogger: logger),
+          equals(-2));
+
+      expect(loggedErrors.length, equals(1));
+    });
+
+    test('onErrorReturn', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      expect(await Future.microtask(() => 1).nullOnError(errorLogger: logger),
+          equals(1));
+      expect(loggedErrors, isEmpty);
+
+      expect(
+          await Future<int>.microtask(() => throw StateError(''))
+              .nullOnError(errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+    });
+  });
+
+  group('FutureNonNullOnErrorExtension', () {
+    test('onComplete', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      var success = [];
+      var errors = [];
+
+      expect(
+          await Future.microtask(() => 1).onComplete(
+              onSuccess: (r) => success.add(r),
+              onError: (e, s) => errors.add(e),
+              errorLogger: logger),
+          equals(1));
+
+      expect(loggedErrors, isEmpty);
+      expect(success, equals([1]));
+      expect(errors, isEmpty);
+
+      expect(
+          await Future<int>.microtask(() => throw StateError('')).onComplete(
+              onSuccess: (r) => success.add(r),
+              onError: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1]));
+      expect(errors.length, equals(1));
+    });
+  });
+
+  group('FutureNullableOnErrorExtension', () {
+    test('onComplete', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      var success = [];
+      var errors = [];
+
+      expect(
+          await Future<int?>.microtask(() => 1).onComplete(
+              onSuccess: (r) => success.add(r),
+              onError: (e, s) => errors.add(e),
+              errorLogger: logger),
+          equals(1));
+
+      expect(loggedErrors, isEmpty);
+      expect(success, equals([1]));
+      expect(errors, isEmpty);
+
+      expect(
+          await Future<int?>.microtask(() => 2).onComplete(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          equals(2));
+
+      expect(loggedErrors, isEmpty);
+      expect(success, equals([1, 2]));
+      expect(errors, isEmpty);
+
+      expect(
+          await Future<int?>.microtask(() => throw StateError('')).onComplete(
+              onSuccess: (r) => success.add(r),
+              onError: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1, 2]));
+      expect(errors.length, equals(1));
+
+      expect(
+          await Future<int?>.microtask(() => null).onComplete(
+              onSuccess: (r) => success.add(r),
+              onError: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1, 2, null]));
+      expect(errors.length, equals(1));
+
+      expect(
+          await Future<int?>.microtask(() => null).onComplete(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1, 2, null]));
+      expect(errors.length, equals(2));
+    });
+
+    test('onCompleteNotNull', () async {
+      var loggedErrors = <(Object?, StackTrace)>[];
+
+      logger(e, s) => loggedErrors.add((e, s));
+
+      var success = [];
+      var errors = [];
+
+      expect(
+          await Future<int?>.microtask(() => 1).onCompleteNotNull(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          equals(1));
+
+      expect(loggedErrors, isEmpty);
+      expect(success, equals([1]));
+      expect(errors, isEmpty);
+
+      expect(
+          await Future<int?>.microtask(() => 2).onCompleteNotNull(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          equals(2));
+
+      expect(loggedErrors, isEmpty);
+      expect(success, equals([1, 2]));
+      expect(errors, isEmpty);
+
+      expect(
+          await Future<int?>.microtask(() => throw StateError(''))
+              .onCompleteNotNull(
+                  onSuccess: (r) => success.add(r),
+                  onErrorOrNull: (e, s) => errors.add(e),
+                  errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1, 2]));
+      expect(errors.length, equals(1));
+
+      expect(
+          await Future<int?>.microtask(() => null).onCompleteNotNull(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(1));
+      expect(success, equals([1, 2]));
+      expect(errors.length, equals(2));
+    });
+  });
+
   group('FutureNullableExtension', () {
     test('Iterable', () async {
       Future<int?> futureInt1 = Future.value(100);

--- a/test/async_extension_test.dart
+++ b/test/async_extension_test.dart
@@ -684,15 +684,26 @@ void main() {
       expect(errors.length, equals(1));
 
       expect(
+          await Future<int?>.microtask(() => throw StateError('')).onComplete(
+              onSuccess: (r) => success.add(r),
+              onErrorOrNull: (e, s) => errors.add(e),
+              errorLogger: logger),
+          isNull);
+
+      expect(loggedErrors.length, equals(2));
+      expect(success, equals([1, 2]));
+      expect(errors.length, equals(2));
+
+      expect(
           await Future<int?>.microtask(() => null).onComplete(
               onSuccess: (r) => success.add(r),
               onError: (e, s) => errors.add(e),
               errorLogger: logger),
           isNull);
 
-      expect(loggedErrors.length, equals(1));
+      expect(loggedErrors.length, equals(2));
       expect(success, equals([1, 2, null]));
-      expect(errors.length, equals(1));
+      expect(errors.length, equals(2));
 
       expect(
           await Future<int?>.microtask(() => null).onComplete(
@@ -701,9 +712,9 @@ void main() {
               errorLogger: logger),
           isNull);
 
-      expect(loggedErrors.length, equals(1));
+      expect(loggedErrors.length, equals(2));
       expect(success, equals([1, 2, null]));
-      expect(errors.length, equals(2));
+      expect(errors.length, equals(3));
     });
 
     test('onCompleteNotNull', () async {


### PR DESCRIPTION
- New `AsyncExtensionErrorLogger` and `defaultAsyncExtensionErrorLogger`:

- New `FutureOnErrorExtension`:
  - `logError`
  - `onErrorReturn`
  - `nullOnError`

- `FutureNonNullOnErrorExtension`:
  - `onComplete`

- `FutureNullableOnErrorExtension`:
  - `onComplete`
  - `onCompleteNotNull`