### PR TITLE
v1.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.18
+
+- `FutureExtension`:
+  - Added method `whenResolved` to invoke a callback on future resolution (success or error) and map the outcome to a new result without automatically rethrowing errors.
+
+- `ComputeOnce`:
+  - Added method `whenComplete` to register a callback executed when resolution completes, regardless of success or failure.
+  - Added method `whenResolved` to invoke a callback on resolution (success or error) and map the outcome to a new result, delegating to `resolveAsync` and `Future.whenResolved`.
+
 ## 1.2.17
 
 - `ComputeOnce`:

--- a/lib/src/async_extension_base.dart
+++ b/lib/src/async_extension_base.dart
@@ -796,6 +796,33 @@ extension FutureExtension<T> on Future<T> {
       });
     }
   }
+
+  /// Invokes a callback when this [Future] resolves, either with a value
+  /// or with an error, and maps the outcome to a new result.
+  ///
+  /// The [onResolve] callback is always executed:
+  /// - On success, it receives the resolved value and `null` error/stackTrace
+  /// - On failure, it receives `null` value along with the error and stackTrace
+  ///
+  /// Unlike [then], errors are **not automatically rethrown**. The value
+  /// returned by [onResolve] becomes the result of the returned [Future].
+  ///
+  /// **Note:** [onResolve] is responsible for deciding how failures are handled.
+  /// It may:
+  /// - Return a fallback value
+  /// - Throw a new error
+  /// - Rethrow the received `error`
+  ///
+  /// This method is useful for handling success and failure uniformly
+  /// while producing a transformed result.
+  Future<R> whenResolved<R>(
+      FutureOr<R> Function(T? value, Object? error, StackTrace? stackTrace)
+          onResolve) {
+    return then(
+      (v) => onResolve(v, null, null),
+      onError: (e, s) => onResolve(null, e, s),
+    );
+  }
 }
 
 typedef AsyncExtensionErrorLogger = void Function(Object? e, StackTrace? s)?;

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'async_extension_base.dart';
+
 /// Signature for a computation executed by [ComputeOnce].
 ///
 /// The callback may return a value synchronously or a [Future] that completes
@@ -157,4 +159,30 @@ class ComputeOnce<V> {
   Future<R> then<R>(FutureOr<R> Function(V value) onValue,
           {Function? onError}) =>
       resolveAsync().then(onValue, onError: onError);
+
+  /// Registers a callback to be executed when resolution completes,
+  /// regardless of success or failure.
+  ///
+  /// Equivalent to calling [resolveAsync] and then invoking
+  /// [Future.whenComplete] on the resulting [Future].
+  Future<V> whenComplete(FutureOr<void> Function() action) =>
+      resolveAsync().whenComplete(action);
+
+  /// Invokes a callback when this value resolves, either successfully
+  /// or with an error, and maps the outcome to a new result.
+  ///
+  /// The [onResolve] callback is always executed:
+  /// - On success, it receives the resolved value and `null` error/stackTrace
+  /// - On failure, it receives `null` value along with the error and stackTrace
+  ///
+  /// Errors are not automatically rethrown. The [onResolve] callback
+  /// determines how failures are handled by choosing to return a value,
+  /// throw a new error, or rethrow the received [error].
+  ///
+  /// This method delegates to [resolveAsync] and then applies
+  /// [Future.whenResolved] on the resulting [Future].
+  Future<R> whenResolved<R>(
+          FutureOr<R> Function(V? value, Object? error, StackTrace? stackTrace)
+              onResolve) =>
+      resolveAsync().whenResolved(onResolve);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_extension
 description: Dart async extensions, to help usage of Future, FutureOr and async methods. Also allows performance improvements when using sync and async code.
-version: 1.2.17
+version: 1.2.18
 homepage: https://github.com/eneural-net/async_extension
 
 environment:


### PR DESCRIPTION
- `FutureExtension`:
  - Added method `whenResolved` to invoke a callback on future resolution (success or error) and map the outcome to a new result without automatically rethrowing errors.

- `ComputeOnce`:
  - Added method `whenComplete` to register a callback executed when resolution completes, regardless of success or failure.
  - Added method `whenResolved` to invoke a callback on resolution (success or error) and map the outcome to a new result, delegating to `resolveAsync` and `Future.whenResolved`.