### PR TITLE
v1.2.19 - TimedComputeOnce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.2.19
+
+- `FunctionArgs0Extension`, `FunctionArgs1Extension`, `FunctionArgs2Extension`:
+  - `tryCall`: updated to catch errors from synchronous or asynchronous results and apply `onError` via `Future.catchError` if the result is a `Future`.
+  
+- `ComputeOnce<V>`:
+  - Added `isResolving` getter to indicate if computation is in progress.
+  - Enhanced `resolve` method:
+    - Added parameters `throwError`, `onError`, and `onErrorValue` to control error handling behavior.
+    - Supports returning fallback values or invoking error handlers instead of always throwing.
+    - Calls `onCompute` callback on completion with value or error.
+  - Enhanced `resolveAsync` method:
+    - Added parameters `throwError`, `onError`, and `onErrorValue` for asynchronous error handling.
+    - Calls `onCompute` callback on completion.
+  - Added `onCompute` callback method invoked once computation completes.
+  - Added `className` getter and improved `toString` to reflect current state (resolving, resolved with value, or error).
+  
+- Added `TimedComputeOnce<V>` subclass:
+  - Records the timestamp when computation resolves (success or failure).
+  - Provides `resolvedAt` timestamp and `elapsedTime` since resolution.
+  - Overrides `onCompute` to set resolution time.
+  - Overrides `className` for identification.
+
 ## 1.2.18
 
 - `FutureExtension`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   - `tryCall`: updated to catch errors from synchronous or asynchronous results and apply `onError` via `Future.catchError` if the result is a `Future`.
   
 - `ComputeOnce<V>`:
+  - Constructor:
+    - Added static helper `_resolveCall` to widen callbacks returning `Future<Never>` to `FutureOr<V>`.
+    - Wrap `_call` with `_resolveCall` to fix `Future<Never>` callbacks.
   - Added `isResolving` getter to indicate if computation is in progress.
   - Enhanced `resolve` method:
     - Added parameters `throwError`, `onError`, and `onErrorValue` to control error handling behavior.

--- a/lib/src/async_extension_base.dart
+++ b/lib/src/async_extension_base.dart
@@ -53,7 +53,12 @@ extension FunctionArgs0Extension<R> on FutureOr<R> Function() {
 
     if (onError != null) {
       try {
-        return f();
+        var r = f();
+        if (r is Future<R>) {
+          return r.catchError(onError);
+        } else {
+          return r;
+        }
       } catch (e, s) {
         return onError(e, s);
       }
@@ -132,7 +137,12 @@ extension FunctionArgs1Extension<R, A> on FutureOr<R> Function(A a) {
 
     if (onError != null) {
       try {
-        return f(a);
+        var r = f(a);
+        if (r is Future<R>) {
+          return r.catchError(onError);
+        } else {
+          return r;
+        }
       } catch (e, s) {
         return onError(e, s);
       }
@@ -211,7 +221,12 @@ extension FunctionArgs2Extension<R, A, B> on FutureOr<R> Function(A a, B b) {
 
     if (onError != null) {
       try {
-        return f(a, b);
+        var r = f(a, b);
+        if (r is Future<R>) {
+          return r.catchError(onError);
+        } else {
+          return r;
+        }
       } catch (e, s) {
         return onError(e, s);
       }

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -53,24 +53,61 @@ class ComputeOnce<V> {
   /// Whether the computation has completed (with value or error).
   bool get isResolved => _result != null;
 
+  /// Whether the computation is currently in progress and not yet resolved.
+  bool get isResolving => _result == null && _future != null;
+
   Future<V>? _future;
 
-  /// Resolves the computation and returns the value (as [V]) or a [Future].
+  /// Resolves the computation and returns its value ([V]) or a [Future<V>].
   ///
-  /// If already resolved, returns the cached value or rethrows the cached error.
-  /// If a resolution is in progress, returns the same Future.
-  FutureOr<V> resolve() {
+  /// - If already resolved, returns the cached value or handles/rethrows
+  ///   the cached error.
+  /// - If a resolution is in progress, returns the same in-flight [Future].
+  /// - When the computation completes (success or failure), [onCompute]
+  ///   is invoked with the resulting value or error.
+  ///
+  /// Parameters:
+  /// - [throwError]:
+  ///   When `true` (default), any error is rethrown with its original
+  ///   [StackTrace]. When `false`, errors are handled by [onError] or
+  ///   [onErrorValue].
+  ///
+  /// - [onError]:
+  ///   Optional error handler invoked when an error occurs and
+  ///   [throwError] is `false`. Receives the error object and its
+  ///   [StackTrace]. Its return value is used as the resolved value.
+  ///
+  /// - [onErrorValue]:
+  ///   Fallback value (default null) returned when an error occurs,
+  ///   [throwError] is `false`, and [onError] is not provided.
+  FutureOr<V> resolve({
+    bool throwError = true,
+    FutureOr<V> Function(Object error, StackTrace stackTrace)? onError,
+    V? onErrorValue,
+  }) {
     var result = _result;
     if (result != null) {
       var error = result.error;
       if (error != null) {
-        Error.throwWithStackTrace(error, result.stackTrace!);
+        var stackTrace = result.stackTrace!;
+        if (throwError) {
+          Error.throwWithStackTrace(error, stackTrace);
+        } else if (onError != null) {
+          return onError(error, stackTrace);
+        } else {
+          return onErrorValue as V;
+        }
       }
       return result.value as V;
     }
 
     var future = _future;
-    if (future != null) return future;
+    if (future != null) {
+      if (!throwError) {
+        return future.catchError(onError ?? (_) => onErrorValue);
+      }
+      return future;
+    }
 
     final FutureOr<V> call;
     try {
@@ -87,6 +124,7 @@ class ComputeOnce<V> {
               _future = null;
             }
             _call = null;
+            onCompute(value, null, null);
           },
           onError: (e, s) {
             _result = (value: null, error: e, stackTrace: s);
@@ -94,41 +132,90 @@ class ComputeOnce<V> {
               _future = null;
             }
             _call = null;
+            onCompute(null, e, s);
           },
         );
 
+        if (!throwError) {
+          return future.catchError(onError ?? (_) => onErrorValue);
+        }
         return future;
       } else {
         _result = (value: call, error: null, stackTrace: null);
         _call = null;
+        onCompute(value, null, null);
         return call;
       }
     } catch (e, s) {
       _result = (value: null, error: e, stackTrace: s);
       _call = null;
-      rethrow;
+      onCompute(null, e, s);
+
+      if (!throwError) {
+        if (onError != null) {
+          return onError(e, s);
+        } else {
+          return onErrorValue as V;
+        }
+      } else {
+        rethrow;
+      }
     }
   }
 
   /// Resolves the computation asynchronously.
   ///
-  /// Always returns a [Future] that completes with the value (as [V]) or error.
+  /// Always returns a [Future<V>] that completes with the resolved value
+  /// or completes with an error.
   ///
-  /// If a resolution is in progress, returns the same Future.
-  /// If already resolved, returns an already completed Future.
-  Future<V> resolveAsync() {
+  /// - If a resolution is in progress, returns the same in-flight [Future].
+  /// - If already resolved, returns an already completed [Future].
+  /// - When the computation completes (success or failure), [onCompute]
+  ///   is invoked with the resulting value or error.
+  ///
+  /// Parameters:
+  /// - [throwError]:
+  ///   When `true` (default), the returned [Future] completes with the
+  ///   original error and [StackTrace]. When `false`, errors are handled
+  ///   by [onError] or [onErrorValue].
+  ///
+  /// - [onError]:
+  ///   Optional asynchronous error handler used only when [throwError]
+  ///   is `false`. Receives the error object and its [StackTrace] and must
+  ///   return a [Future<V>] whose value becomes the resolution result.
+  ///
+  /// - [onErrorValue]:
+  ///   Fallback value (default null) used to complete the returned [Future]
+  ///   when an error occurs, [throwError] is `false`, and [onError] is not
+  ///   provided.
+  Future<V> resolveAsync({
+    bool throwError = true,
+    Future<V> Function(Object error, StackTrace stackTrace)? onError,
+    V? onErrorValue,
+  }) {
     var result = _result;
     if (result != null) {
       var error = result.error;
       if (error != null) {
-        var stackTrace = result.stackTrace;
-        return Future.error(error, stackTrace);
+        var stackTrace = result.stackTrace!;
+        if (throwError) {
+          return Future.error(error, stackTrace);
+        } else if (onError != null) {
+          return onError(error, stackTrace);
+        } else {
+          return Future.value(onErrorValue ?? (null as V));
+        }
       }
       return Future.value(result.value as V);
     }
 
     var future = _future;
-    if (future != null) return future;
+    if (future != null) {
+      if (!throwError) {
+        return future.catchError(onError ?? (_) => onErrorValue);
+      }
+      return future;
+    }
 
     var computer = _call ?? (throw StateError("Null `_call`"));
     future = _future = Future(computer);
@@ -140,6 +227,7 @@ class ComputeOnce<V> {
           _future = null;
         }
         _call = null;
+        onCompute(value, null, null);
       },
       onError: (e, s) {
         _result = (value: null, error: e, stackTrace: s);
@@ -147,11 +235,21 @@ class ComputeOnce<V> {
           _future = null;
         }
         _call = null;
+        onCompute(null, e, s);
       },
     );
 
+    if (!throwError) {
+      return future.catchError(onError ?? (_) => onErrorValue);
+    }
     return future;
   }
+
+  /// Callback invoked when the computation completes.
+  ///
+  /// Exactly one of [value] or [error] will be non-null.
+  /// If [error] is non-null, [stackTrace] contains the associated stack trace.
+  void onCompute(V? value, Object? error, StackTrace? stackTrace) {}
 
   /// Chains a callback to the resolved value.
   ///
@@ -185,4 +283,57 @@ class ComputeOnce<V> {
           FutureOr<R> Function(V? value, Object? error, StackTrace? stackTrace)
               onResolve) =>
       resolveAsync().whenResolved(onResolve);
+
+  /// The class name of this compute implementation.
+  ///
+  /// Intended to be overridden by subclasses to return their own class name.
+  String get className => 'ComputeOnce';
+
+  @override
+  String toString() {
+    if (isResolved) {
+      if (hasError) {
+        return '$className<$V>[error: ${_result?.error}]\n'
+            '${_result?.stackTrace}';
+      } else {
+        return '$className<$V><${_result?.value}>';
+      }
+    } else if (isResolving) {
+      return '$className<$V>[resolving...]';
+    } else {
+      return '$className<$V>@$_call';
+    }
+  }
+}
+
+/// A [ComputeOnce] that records when the computation is resolved.
+///
+/// The [resolvedAt] timestamp is set when the computation completes,
+/// regardless of success or failure.
+class TimedComputeOnce<V> extends ComputeOnce<V> {
+  TimedComputeOnce(super.call, {super.resolve});
+
+  DateTime? _resolvedAt;
+
+  /// The moment the computation was resolved, or `null` if not yet resolved.
+  DateTime? get resolvedAt => _resolvedAt;
+
+  /// Returns the time elapsed since the computation was resolved.
+  ///
+  /// If the computation has not yet been resolved, returns [Duration.zero].
+  /// The optional [now] parameter allows using a custom reference time.
+  Duration elapsedTime([DateTime? now]) {
+    var resolvedAt = this.resolvedAt;
+    if (resolvedAt == null) return Duration.zero;
+    now ??= DateTime.now();
+    return now.difference(resolvedAt);
+  }
+
+  @override
+  String get className => 'TimedComputeOnce';
+
+  @override
+  void onCompute(V? value, Object? error, StackTrace? stackTrace) {
+    _resolvedAt = DateTime.now();
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_extension
 description: Dart async extensions, to help usage of Future, FutureOr and async methods. Also allows performance improvements when using sync and async code.
-version: 1.2.18
+version: 1.2.19
 homepage: https://github.com/eneural-net/async_extension
 
 environment:

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -293,6 +293,44 @@ void main() {
     expect(c.hasError, isTrue);
   });
 
+  test('resolve with throwError=false returns fallback value on async error',
+      () async {
+    final error = StateError('fail');
+
+    final c = ComputeOnce<int>(() async {
+      throw error;
+    }, resolve: false);
+
+    final v = await c.resolve(
+      throwError: false,
+      onErrorValue: 99,
+    );
+
+    expect(v, 99);
+    expect(c.isResolved, isTrue);
+    expect(c.hasError, isTrue);
+  });
+
+  test('resolve with throwError=false uses onError callback', () async {
+    final error = ArgumentError('bad');
+
+    final c = ComputeOnce<int>(() async {
+      throw error;
+    }, resolve: false);
+
+    final v = await c.resolve(
+      throwError: false,
+      onError: (e, s) {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 42;
+      },
+    );
+
+    expect(v, 42);
+    expect(c.hasError, isTrue);
+  });
+
   test('resolveAsync with throwError=false returns fallback on async error',
       () async {
     final error = StateError('boom');

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -1,6 +1,5 @@
-import 'package:test/test.dart';
-
 import 'package:async_extension/async_extension.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('ComputeOnce', () {
@@ -238,4 +237,178 @@ void main() {
       );
     });
   });
+
+  test('isResolving is true while async computation is in flight', () async {
+    final c = ComputeOnce<int>(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      return 1;
+    }, resolve: false);
+
+    final f = c.resolveAsync();
+
+    expect(c.isResolved, isFalse);
+    expect(c.isResolving, isTrue);
+
+    await f;
+
+    expect(c.isResolving, isFalse);
+    expect(c.isResolved, isTrue);
+  });
+
+  test('resolve with throwError=false returns fallback value on sync error',
+      () {
+    final error = StateError('fail');
+
+    final c = ComputeOnce<int>(() {
+      throw error;
+    }, resolve: false);
+
+    final v = c.resolve(
+      throwError: false,
+      onErrorValue: 99,
+    );
+
+    expect(v, 99);
+    expect(c.isResolved, isTrue);
+    expect(c.hasError, isTrue);
+  });
+
+  test('resolve with throwError=false uses onError callback', () {
+    final error = ArgumentError('bad');
+
+    final c = ComputeOnce<int>(() {
+      throw error;
+    }, resolve: false);
+
+    final v = c.resolve(
+      throwError: false,
+      onError: (e, s) {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 42;
+      },
+    );
+
+    expect(v, 42);
+    expect(c.hasError, isTrue);
+  });
+
+  test('resolveAsync with throwError=false returns fallback on async error',
+      () async {
+    final error = StateError('boom');
+
+    final c = ComputeOnce<int>(() async {
+      throw error;
+    }, resolve: false);
+
+    final v = await c.resolveAsync(
+      throwError: false,
+      onErrorValue: 7,
+    );
+
+    expect(v, 7);
+    expect(c.isResolved, isTrue);
+    expect(c.hasError, isTrue);
+  });
+
+  test('resolveAsync with throwError=false uses async onError handler',
+      () async {
+    final error = ArgumentError('fail');
+
+    final c = ComputeOnce<int>(() async {
+      throw error;
+    }, resolve: false);
+
+    final v = await c.resolveAsync(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 123;
+      },
+    );
+
+    expect(v, 123);
+    expect(c.hasError, isTrue);
+  });
+
+  test('onCompute is called exactly once on success', () async {
+    final c = _MyComputeOnce<int>(() async => 5, resolve: false);
+
+    await c.resolveAsync();
+
+    var onComputeArgs = c.onComputeArgs;
+    expect(onComputeArgs!.$1, 5);
+    expect(onComputeArgs.$2, isNull);
+    expect(onComputeArgs.$3, isNull);
+  });
+
+  test('onCompute is called exactly once on failure', () async {
+    final error = StateError('fail');
+
+    final c = _MyComputeOnce<int>(() {
+      throw error;
+    }, resolve: false);
+
+    await expectLater(c.resolveAsync(), throwsA(same(error)));
+
+    var onComputeArgs = c.onComputeArgs;
+    expect(onComputeArgs!.$1, isNull);
+    expect(onComputeArgs.$2, same(error));
+    expect(onComputeArgs.$3, isNotNull);
+  });
+
+  test('toString reflects resolving, success and error states', () async {
+    final c1 = ComputeOnce<int>(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return 1;
+    }, resolve: false);
+
+    final f = c1.resolveAsync();
+    expect(c1.toString(), contains('resolving'));
+
+    await f;
+    expect(c1.toString(), contains('<1>'));
+
+    final c2 = ComputeOnce<int>(() {
+      throw StateError('x');
+    }, resolve: false);
+
+    try {
+      c2.resolve();
+    } catch (_) {}
+
+    expect(c2.toString(), contains('error'));
+  });
+
+  group('TimedComputeOnce', () {
+    test('TimedComputeOnce sets resolvedAt on success and failure', () async {
+      final c1 = TimedComputeOnce<int>(() => 10, resolve: false);
+      await c1.resolveAsync();
+
+      expect(c1.resolvedAt, isNotNull);
+      expect(c1.elapsedTime().inMilliseconds, greaterThanOrEqualTo(0));
+
+      final c2 = TimedComputeOnce<int>(() {
+        throw StateError('fail');
+      }, resolve: false);
+
+      try {
+        c2.resolve();
+      } catch (_) {}
+
+      expect(c2.resolvedAt, isNotNull);
+    });
+  });
+}
+
+class _MyComputeOnce<V> extends ComputeOnce<V> {
+  _MyComputeOnce(super.call, {super.resolve});
+
+  (V?, Object?, StackTrace?)? onComputeArgs;
+
+  @override
+  void onCompute(V? value, Object? error, StackTrace? stackTrace) {
+    onComputeArgs = (value, error, stackTrace);
+  }
 }

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -370,6 +370,88 @@ void main() {
     expect(c.hasError, isTrue);
   });
 
+  test('resolve with delay+throwError=false uses async onError handler',
+      () async {
+    final error = ArgumentError('fail');
+
+    final c = ComputeOnce<int>(() async {
+      await Future.delayed(Duration(milliseconds: 100));
+      throw error;
+    }, resolve: false);
+
+    final v1Async = c.resolve(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 123;
+      },
+    );
+
+    final v2Async = c.resolve(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 456;
+      },
+    );
+
+    final v3Async = c.resolve(throwError: false, onErrorValue: 789);
+
+    final v1 = await v1Async;
+    final v2 = await v2Async;
+    final v3 = await v3Async;
+
+    expect(c.hasError, isTrue);
+    expect(c.error?.error, same(error));
+
+    expect(v1, 123);
+    expect(v2, 456);
+    expect(v3, 789);
+  });
+
+  test('resolveAsync with delay+throwError=false uses async onError handler',
+      () async {
+    final error = ArgumentError('fail');
+
+    final c = ComputeOnce<int>(() async {
+      await Future.delayed(Duration(milliseconds: 100));
+      throw error;
+    }, resolve: false);
+
+    final v1Async = c.resolveAsync(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 123;
+      },
+    );
+
+    final v2Async = c.resolveAsync(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return 456;
+      },
+    );
+
+    final v3Async = c.resolveAsync(throwError: false, onErrorValue: 789);
+
+    final v1 = await v1Async;
+    final v2 = await v2Async;
+    final v3 = await v3Async;
+
+    expect(c.hasError, isTrue);
+    expect(c.error?.error, same(error));
+
+    expect(v1, 123);
+    expect(v2, 456);
+    expect(v3, 789);
+  });
+
   test('onCompute is called exactly once on success', () async {
     final c = _MyComputeOnce<int>(() async => 5, resolve: false);
 

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -409,6 +409,21 @@ void main() {
     expect(v1, 123);
     expect(v2, 456);
     expect(v3, 789);
+
+    final v4 = await c.resolve(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return -123;
+      },
+    );
+
+    expect(v4, -123);
+
+    final v5 = await c.resolve(throwError: false, onErrorValue: -456);
+
+    expect(v5, -456);
   });
 
   test('resolveAsync with delay+throwError=false uses async onError handler',
@@ -450,6 +465,21 @@ void main() {
     expect(v1, 123);
     expect(v2, 456);
     expect(v3, 789);
+
+    final v4 = await c.resolveAsync(
+      throwError: false,
+      onError: (e, s) async {
+        expect(e, same(error));
+        expect(s, isNotNull);
+        return -123;
+      },
+    );
+
+    expect(v4, -123);
+
+    final v5 = await c.resolveAsync(throwError: false, onErrorValue: -456);
+
+    expect(v5, -456);
   });
 
   test('onCompute is called exactly once on success', () async {
@@ -483,6 +513,8 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
       return 1;
     }, resolve: false);
+
+    expect(c1.toString(), contains('@'));
 
     final f = c1.resolveAsync();
     expect(c1.toString(), contains('resolving'));

--- a/test/async_extension_test.dart
+++ b/test/async_extension_test.dart
@@ -147,6 +147,23 @@ void main() {
           call2.asFutureOr.tryCall(3, onError: (e, s) => -100), equals(-100));
     });
 
+    test('tryCall (async)', () async {
+      var call1 = ((int n) async => n * 10);
+
+      expect(await call1.tryCall(2, onError: (e, s) => -100), equals(20));
+
+      expect(await call1.asFutureOr.tryCall(2, onError: (e, s) => -100),
+          equals(20));
+
+      var call2 = ((int n) async =>
+          DateTime.now().year > 2000 ? throw StateError("Error") : n * 10);
+
+      expect(await call2.tryCall(3, onError: (e, s) => -100), equals(-100));
+
+      expect(await call2.asFutureOr.tryCall(3, onError: (e, s) => -100),
+          equals(-100));
+    });
+
     test('tryCallThen', () async {
       var call1 = ((int n) => n * 10);
 
@@ -203,6 +220,23 @@ void main() {
           equals(-100));
 
       expect(call2.tryCall(2, 3, onError: (e, s) => -100), equals(-100));
+    });
+
+    test('tryCall (async)', () async {
+      var call1 = ((int n, int m) async => n * m);
+
+      expect(await call1.tryCall(2, 3, onError: (e, s) => -100), equals(6));
+
+      expect(await call1.asFutureOr.tryCall(2, 3, onError: (e, s) => -100),
+          equals(6));
+
+      var call2 = ((int n, int m) async =>
+          DateTime.now().year > 2000 ? throw StateError("Error") : n * m);
+
+      expect(await call2.asFutureOr.tryCall(2, 3, onError: (e, s) => -100),
+          equals(-100));
+
+      expect(await call2.tryCall(2, 3, onError: (e, s) => -100), equals(-100));
     });
 
     test('tryCallThen', () async {


### PR DESCRIPTION
- `FunctionArgs0Extension`, `FunctionArgs1Extension`, `FunctionArgs2Extension`:
  - `tryCall`: updated to catch errors from synchronous or asynchronous results and apply `onError` via `Future.catchError` if the result is a `Future`.

- `ComputeOnce<V>`:
  - Added `isResolving` getter to indicate if computation is in progress.
  - Enhanced `resolve` method:
    - Added parameters `throwError`, `onError`, and `onErrorValue` to control error handling behavior.
    - Supports returning fallback values or invoking error handlers instead of always throwing.
    - Calls `onCompute` callback on completion with value or error.
  - Enhanced `resolveAsync` method:
    - Added parameters `throwError`, `onError`, and `onErrorValue` for asynchronous error handling.
    - Calls `onCompute` callback on completion.
  - Added `onCompute` callback method invoked once computation completes.
  - Added `className` getter and improved `toString` to reflect current state (resolving, resolved with value, or error).

- Added `TimedComputeOnce<V>` subclass:
  - Records the timestamp when computation resolves (success or failure).
  - Provides `resolvedAt` timestamp and `elapsedTime` since resolution.
  - Overrides `onCompute` to set resolution time.
  - Overrides `className` for identification.