### PR TITLE
v1.2.20 - Feature: ComputeOnceCachedIDs - batched computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 1.2.20
+
+- `ComputeOnce`:
+  - Renamed `ComputeOnceCall` to `ComputeCall`.
+  - Added `PosComputeCall` callback invoked after computation completes, receiving success or error results.
+  - Added `posCompute` field to invoke post-computation callback.
+  - Updated `resolve` and `resolveAsync` to apply `posCompute` on success or error.
+
+- `TimedComputeOnce`:
+  - Added support for `posCompute` callback.
+
+- Added `ComputeOnceCache`:
+  - Caches `TimedComputeOnce` instances by key.
+  - Supports retention duration for cached entries with automatic eviction.
+  - Provides `get` method to retrieve or create cached computations.
+
+- Added `ComputeOnceCachedIDs`:
+  - Extends `ComputeOnceCache` for batched computations by ID sets.
+  - Supports ID ordering, hashing, and deduplication.
+  - Shares in-flight computations for overlapping ID sets.
+  - Provides `getByIDs` to get computations for subsets of IDs.
+  - Provides `computeIDs` to compute and merge results for requested IDs, preserving order.
+
+- Added `ComputeIDs`:
+  - Represents an ordered, comparable, and hashable set of IDs.
+  - Supports binary search, intersection, equality, and hashing.
+
+- Added extensions:
+  - `IterableComputeOnceEtension` for resolving multiple `ComputeOnce` instances.
+  - `MapComputeIDsEtension` for resolving maps of `TimedComputeOnce` keyed by `ComputeIDs`.
+  - `ListIdValuePairExtension` for binary searching `(ID, value)` pairs sorted by ID.
+
+- Typedefs:
+  - `ComputeCallIDs` for batched ID computations.
+  - `ComputeIDCompare` and `ComputeIDHash` for ID comparison and hashing.
+
 ## 1.2.19
 
 - `FunctionArgs0Extension`, `FunctionArgs1Extension`, `FunctionArgs2Extension`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
   - Supports binary search, intersection, equality, and hashing.
 
 - Added extensions:
-  - `IterableComputeOnceEtension` for resolving multiple `ComputeOnce` instances.
-  - `MapComputeIDsEtension` for resolving maps of `TimedComputeOnce` keyed by `ComputeIDs`.
+  - `IterableComputeOnceExtension` for resolving multiple `ComputeOnce` instances.
+  - `MapComputeIDsExtension` for resolving maps of `TimedComputeOnce` keyed by `ComputeIDs`.
   - `ListIdValuePairExtension` for binary searching `(ID, value)` pairs sorted by ID.
 
 - Typedefs:

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -195,7 +195,7 @@ class ComputeOnce<V> {
         _result = (value: value, error: null, stackTrace: null);
         _call = null;
         onCompute(value, null, null);
-        return call;
+        return value;
       }
     } catch (e, s) {
       return resolveError(e, s);

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -122,7 +122,7 @@ class ComputeOnce<V> {
         } else if (onError != null) {
           return onError(error, stackTrace);
         } else {
-          return onErrorValue as V;
+          return _castErrorValue(onErrorValue);
         }
       }
       return result.value as V;
@@ -134,7 +134,7 @@ class ComputeOnce<V> {
         if (onError != null) {
           return future.catchError(onError);
         } else {
-          return future.catchError((e, s) => onErrorValue as V);
+          return future.catchError((e, s) => _castErrorValue(onErrorValue));
         }
       }
       return future;
@@ -149,7 +149,7 @@ class ComputeOnce<V> {
         if (onError != null) {
           return onError(e, s);
         } else {
-          return onErrorValue as V;
+          return _castErrorValue(onErrorValue);
         }
       } else {
         Error.throwWithStackTrace(e, s);
@@ -254,7 +254,7 @@ class ComputeOnce<V> {
         if (onError != null) {
           return future.catchError(onError);
         } else {
-          return future.catchError((e, s) => onErrorValue as V);
+          return future.catchError((e, s) => _castErrorValue(onErrorValue));
         }
       }
       return future;
@@ -273,6 +273,22 @@ class ComputeOnce<V> {
     }
 
     return _resolveFuture(future, throwError, onError, onErrorValue);
+  }
+
+  V _castErrorValue(V? onErrorValue) {
+    try {
+      return onErrorValue as V;
+    } catch (e) {
+      var msg = "Can't cast `onErrorValue` to `$V`: $onErrorValue";
+      if (onErrorValue == null) {
+        throw StateError(
+            "$this [throwError: false, `onError`: null ; `onErrorValue`: null]> $msg");
+      } else {
+        throw StateError(
+            "$this [throwError: false, `onError`: null ; `onErrorValue`: `$onErrorValue`]> $msg");
+      }
+    }
+  }
 
   Future<V> _resolveFuture(
       Future<V> future,

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -548,11 +548,6 @@ class ComputeOnceCachedIDs<D extends Object, V>
 
     var idsNotCalling = ids.toList();
 
-    if (idsNotCalling.isEmpty) {
-      var computers = Map.fromEntries(calling);
-      return computers;
-    }
-
     idsNotCalling.sort((a, b) => compare(a, b));
 
     for (var callIDs in callingIDs) {
@@ -562,6 +557,11 @@ class ComputeOnceCachedIDs<D extends Object, V>
           idsNotCalling.removeAt(idx);
         }
       }
+    }
+
+    if (idsNotCalling.isEmpty) {
+      var computers = Map.fromEntries(calling);
+      return computers;
     }
 
     final idsNotCallingKey =

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -542,10 +542,23 @@ class ComputeOnceCachedIDs<D extends Object, V>
 
     var callingIDs = calling.map((c) => c.key.ids);
 
+    final compare = this.compare ?? _Comparer._defaultCompare;
+
     var idsNotCalling = ids.toList();
+
+    if (idsNotCalling.isEmpty) {
+      var computers = Map.fromEntries(calling);
+      return computers;
+    }
+
+    idsNotCalling.sort((a, b) => compare(a, b));
+
     for (var callIDs in callingIDs) {
       for (var id in callIDs) {
-        idsNotCalling.remove(id);
+        var idx = _Comparer.binarySearchIndex(idsNotCalling, id, compare);
+        if (idx >= 0) {
+          idsNotCalling.removeAt(idx);
+        }
       }
     }
 

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -586,7 +586,7 @@ class ComputeOnceCachedIDs<D extends Object, V>
         var intersectionIDs = computedIDs.intersection(ids);
         if (intersectionIDs.isEmpty) return <(D, V)>[];
 
-        if (intersectionIDs.length == ids.length) {
+        if (intersectionIDs.length == computedIDs.length) {
           var values = List.generate(computedIDs.length, (i) {
             var id = computedIDs[i];
             var v = computedValues[i];

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -899,7 +899,7 @@ abstract class _Comparer {
 }
 
 /// Utilities to resolve multiple [ComputeOnce] instances.
-extension IterableComputeOnceEtension<V> on Iterable<ComputeOnce<V>> {
+extension IterableComputeOnceExtension<V> on Iterable<ComputeOnce<V>> {
   /// Resolves all computations and returns their results in iteration order.
   ///
   /// If [throwError] is true, the first error is propagated.
@@ -933,7 +933,7 @@ extension IterableComputeOnceEtension<V> on Iterable<ComputeOnce<V>> {
 
 /// Utilities to resolve all [TimedComputeOnce] values in a map keyed by
 /// [ComputeIDs].
-extension MapComputeIDsEtension<D extends Object, V>
+extension MapComputeIDsExtension<D extends Object, V>
     on Map<ComputeIDs<D>, TimedComputeOnce<V>> {
   /// Resolves all computations and returns a map with the same keys.
   ///

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -6,7 +6,14 @@ import 'async_extension_base.dart';
 ///
 /// The callback may return a value synchronously or a [Future] that completes
 /// with the value [V] or an error.
-typedef ComputeOnceCall<V> = FutureOr<V> Function();
+typedef ComputeCall<V> = FutureOr<V> Function();
+
+/// Callback invoked after a computation completes.
+///
+/// [value] is non-null on success.
+/// [error] and [stackTrace] are non-null on failure.
+typedef PosComputeCall<V> = V Function(
+    V? value, Object? error, StackTrace? stackTrace)?;
 
 /// Lazily computes a value at most once and caches either the result or error.
 ///
@@ -19,12 +26,18 @@ class ComputeOnce<V> {
   ///
   /// This is cleared after a successful or failed [resolve]/[resolveAsync] to
   /// release references and prevent the computation from being invoked again.
-  ComputeOnceCall<V>? _call;
+  ComputeCall<V>? _call;
+
+  /// Optional callback invoked after the computation completes.
+  ///
+  /// On success, [value] is non-null.
+  /// On failure, [error] and [stackTrace] are non-null.
+  PosComputeCall<V>? posCompute;
 
   /// Creates a [ComputeOnce] wrapping [_call].
   ///
   /// If [resolve] is true, starts resolving immediately.
-  ComputeOnce(ComputeOnceCall<V> call, {bool resolve = true})
+  ComputeOnce(ComputeCall<V> call, {this.posCompute, bool resolve = true})
       : _call = _resolveCall(call) {
     if (resolve) {
       resolveAsync();
@@ -36,7 +49,7 @@ class ComputeOnce<V> {
   /// A `Future<Never>` cannot produce a `V`, which breaks `onError` and
   /// `onErrorValue`. This wraps the call so it is treated as
   /// `FutureOr<V> Function()` while preserving behavior.
-  static ComputeOnceCall<V> _resolveCall<V>(ComputeOnceCall<V> call) {
+  static ComputeCall<V> _resolveCall<V>(ComputeCall<V> call) {
     if (call is Future<Never> Function()) {
       Future<V> callCast() => call().then<V>((v) => v as V);
       return callCast;
@@ -127,13 +140,39 @@ class ComputeOnce<V> {
       return future;
     }
 
+    FutureOr<V> resolveError(Object e, StackTrace s) {
+      _result = (value: null, error: e, stackTrace: s);
+      _call = null;
+      onCompute(null, e, s);
+
+      if (!throwError) {
+        if (onError != null) {
+          return onError(e, s);
+        } else {
+          return onErrorValue as V;
+        }
+      } else {
+        Error.throwWithStackTrace(e, s);
+      }
+    }
+
+    final posCompute = this.posCompute;
     final FutureOr<V> call;
+
     try {
       var computer = _call ?? (throw StateError("Null `_call`"));
       call = computer();
 
       if (call is Future<V>) {
         future = _future = call;
+
+        if (posCompute != null) {
+          future = _future = future.then((v) {
+            return posCompute(v, null, null);
+          }, onError: (e, s) {
+            return posCompute(null, e, s);
+          });
+        }
 
         future.then(
           (value) {
@@ -161,27 +200,25 @@ class ComputeOnce<V> {
             return future.catchError((e, s) => onErrorValue as V);
           }
         }
+
         return future;
       } else {
-        _result = (value: call, error: null, stackTrace: null);
+        var value = call;
+        if (posCompute != null) {
+          try {
+            value = posCompute(value, null, null);
+          } catch (e, s) {
+            return resolveError(e, s);
+          }
+        }
+
+        _result = (value: value, error: null, stackTrace: null);
         _call = null;
         onCompute(value, null, null);
         return call;
       }
     } catch (e, s) {
-      _result = (value: null, error: e, stackTrace: s);
-      _call = null;
-      onCompute(null, e, s);
-
-      if (!throwError) {
-        if (onError != null) {
-          return onError(e, s);
-        } else {
-          return onErrorValue as V;
-        }
-      } else {
-        rethrow;
-      }
+      return resolveError(e, s);
     }
   }
 
@@ -245,6 +282,15 @@ class ComputeOnce<V> {
 
     var computer = _call ?? (throw StateError("Null `_call`"));
     future = _future = Future(computer);
+
+    final posCompute = this.posCompute;
+    if (posCompute != null) {
+      future = _future = future.then((v) {
+        return posCompute(v, null, null);
+      }, onError: (e, s) {
+        return posCompute(null, e, s);
+      });
+    }
 
     future.then(
       (value) {
@@ -341,7 +387,7 @@ class ComputeOnce<V> {
 /// The [resolvedAt] timestamp is set when the computation completes,
 /// regardless of success or failure.
 class TimedComputeOnce<V> extends ComputeOnce<V> {
-  TimedComputeOnce(super.call, {super.resolve});
+  TimedComputeOnce(super.call, {super.posCompute, super.resolve});
 
   DateTime? _resolvedAt;
 
@@ -366,4 +412,566 @@ class TimedComputeOnce<V> extends ComputeOnce<V> {
   void onCompute(V? value, Object? error, StackTrace? stackTrace) {
     _resolvedAt = DateTime.now();
   }
+}
+
+/// Caches [TimedComputeOnce] instances by key, ensuring each computation
+/// is executed only once while retained.
+///
+/// After resolution, entries are kept for [retentionDuration]. When the
+/// duration is zero, entries are removed immediately.
+class ComputeOnceCache<K extends Object, V> {
+  /// How long a resolved computation is kept in the cache.
+  final Duration retentionDuration;
+
+  /// Creates a cache with an optional [retentionDuration].
+  ///
+  /// Defaults to [Duration.zero], meaning immediate eviction after resolve.
+  ComputeOnceCache({this.retentionDuration = Duration.zero});
+
+  final _calls = <K, TimedComputeOnce<V>>{};
+  final _timers = <K, Timer>{};
+
+  /// Returns an existing [TimedComputeOnce] for [key] or creates a new one.
+  ///
+  /// - [call] is executed at most once per key while retained.
+  /// - [posCompute], if provided, is invoked after resolution and before the end of the retention period.
+  /// - If [resolve] is true, the computation may resolve eagerly.
+  TimedComputeOnce<V> get(K key, ComputeCall<V> call,
+      {PosComputeCall<V>? posCompute, bool resolve = true}) {
+    var computer = _calls[key];
+    if (computer != null) {
+      return computer;
+    }
+
+    computer = _calls[key] =
+        TimedComputeOnce(call, posCompute: posCompute, resolve: resolve);
+
+    computer.whenResolved((v, e, s) {
+      final prev = _calls[key];
+      if (!identical(prev, computer)) return;
+
+      if (retentionDuration == Duration.zero) {
+        _removeInternal(key);
+      } else {
+        _timers[key]?.cancel();
+        _timers[key] = Timer(retentionDuration, () {
+          final prev = _calls[key];
+          if (identical(prev, computer)) {
+            _removeInternal(key);
+          }
+        });
+      }
+    });
+
+    return computer;
+  }
+
+  TimedComputeOnce<V>? _removeInternal(K key) {
+    _timers.remove(key)?.cancel();
+    return _calls.remove(key);
+  }
+
+  /// Removes a cached computation and cancels any associated timer.
+  TimedComputeOnce<V>? remove(K key) => _removeInternal(key);
+
+  /// Returns a snapshot of current cached computations.
+  Map<K, TimedComputeOnce<V>> calls() => Map.from(_calls);
+
+  /// Clears the cache and cancels all retention timers.
+  void clear() {
+    for (final t in _timers.values) {
+      t.cancel();
+    }
+    _timers.clear();
+    _calls.clear();
+  }
+}
+
+/// Signature for computing values for a list of IDs.
+///
+/// The callback receives a list of IDs and returns a list of values in the
+/// same order, either synchronously or asynchronously.
+typedef ComputeCallIDs<D extends Object, V> = FutureOr<List<V>> Function(
+    List<D> ids);
+
+/// A [ComputeOnceCache] specialized for batched computations by ID.
+///
+/// Requests with overlapping ID sets share in-flight computations.
+/// Results are merged, deduplicated, and returned in the same order as
+/// the requested IDs.
+class ComputeOnceCachedIDs<D extends Object, V>
+    extends ComputeOnceCache<ComputeIDs<D>, List<V>> {
+  /// Optional comparator used to order IDs and results.
+  final ComputeIDCompare<D>? compare;
+
+  /// Optional hash function used for IDs.
+  final ComputeIDHash<D>? hash;
+
+  /// Creates a cache for batched ID-based computations.
+  ///
+  /// [compare] defines ID ordering and equality.
+  /// [hash] defines how IDs are grouped internally.
+  ComputeOnceCachedIDs(
+      {super.retentionDuration, ComputeIDCompare<D>? compare, this.hash})
+      : compare = _Comparer.resolveCompare(compare);
+
+  /// Returns computations for the given [ids], reusing any overlapping
+  /// in-flight computations.
+  ///
+  /// - Only IDs not already being computed will trigger a new call.
+  /// - [posCompute], if provided, is invoked after each computation resolves.
+  /// - If [resolve] is true, computations may resolve eagerly.
+  ///
+  /// Returns a map of computations keyed by their ID sets.
+  ///
+  /// Each entry represents a computation responsible for a subset of [ids].
+  /// Existing in-flight computations are reused, and a new computation is
+  /// created only for IDs not currently being computed.
+  ///
+  /// The returned map contains all computations required to fully resolve
+  /// the requested [ids].
+  ///
+  /// See [computeIDs].
+  Map<ComputeIDs<D>, TimedComputeOnce<List<V>>> getByIDs(
+      List<D> ids, ComputeCallIDs<D, V> call,
+      {PosComputeCall<List<V>>? posCompute, bool resolve = true}) {
+    var calling = _calls.entries.where((e) => e.key.containsAny(ids)).toList();
+
+    var callingIDs = calling.map((c) => c.key.ids);
+
+    var idsNotCalling = ids.toList();
+    for (var callIDs in callingIDs) {
+      for (var id in callIDs) {
+        idsNotCalling.remove(id);
+      }
+    }
+
+    final idsNotCallingKey =
+        ComputeIDs(idsNotCalling, compare: compare, hash: hash);
+
+    var computer = get(idsNotCallingKey, () => call(idsNotCallingKey.ids),
+        resolve: resolve);
+
+    var computers = Map.fromEntries([
+      MapEntry(idsNotCallingKey, computer),
+      ...calling,
+    ]);
+
+    return computers;
+  }
+
+  /// Computes values for the given [ids], reusing and composing the
+  /// computations returned by [getByIDs].
+  ///
+  /// Overlapping or in-flight ID computations are shared, and only missing
+  /// IDs trigger new computation.
+  ///
+  /// The returned list respects the order of [ids] and contains `(ID, value)`
+  /// pairs aligned with the input sequence.
+  ///
+  /// The result may be returned synchronously or asynchronously.
+  FutureOr<List<(D, V)>> computeIDs(List<D> ids, ComputeCallIDs<D, V> call,
+      {PosComputeCall<List<V>>? posCompute, bool resolve = true}) {
+    var computers =
+        getByIDs(ids, call, posCompute: posCompute, resolve: resolve);
+
+    return computers.computeAll().resolveMapped((results) {
+      var allComputations = results.entries.map((e) {
+        var computedIDs = e.key;
+        var computedValues = e.value;
+
+        var intersectionIDs = computedIDs.intersection(ids);
+        if (intersectionIDs.isEmpty) return <(D, V)>[];
+
+        if (intersectionIDs.length == ids.length) {
+          var values = List.generate(computedIDs.length, (i) {
+            var id = computedIDs[i];
+            var v = computedValues[i];
+            return (id, v);
+          });
+          return values;
+        }
+
+        var intersectionValues = computedIDs.getValuesByIndexes(
+          intersectionIDs.map((e) => e.$1),
+          computedValues,
+        );
+
+        return intersectionValues;
+      }).toList();
+
+      if (allComputations.isEmpty) {
+        return [];
+      }
+
+      final cmp = compare ?? _Comparer._defaultCompare;
+
+      List<(D, V)> allComputedValues;
+
+      if (allComputations.length == 1) {
+        // Already sorted:
+        allComputedValues = allComputations.first;
+      } else {
+        allComputedValues = allComputations.expand((l) => l).toList();
+        // Ensure sorted:
+        if (allComputedValues.length > 1) {
+          allComputedValues.sort((a, b) => cmp(a.$1, b.$1));
+        }
+      }
+
+      if (allComputedValues.length <= 1) {
+        assert(allComputedValues.isEmpty ||
+            ids.contains(allComputedValues.first.$1));
+
+        return allComputedValues;
+      }
+
+      var idsValues = ids
+          .map((id) => allComputedValues.binarySearch(id, cmp))
+          .nonNulls
+          .toList();
+
+      return idsValues;
+    });
+  }
+}
+
+/// Binary-search utilities for lists of `(ID, value)` pairs.
+///
+/// The list **must be sorted by ID** according to the provided comparator
+/// (or the default comparator) for correct results.
+extension ListIdValuePairExtension<D extends Object, V> on List<(D, V)> {
+  /// Returns the index of the entry with the given [id], or `-1` if not found.
+  ///
+  /// Uses binary search and runs in `O(log n)`.
+  /// The list must be sorted by ID using [compare].
+  int binarySearchIndex(D id, [ComputeIDCompare<D>? compare]) {
+    if (isEmpty) return -1;
+    compare ??= _Comparer._defaultCompare;
+    var v0 = first.$2;
+    return _Comparer.binarySearchIndex<(D, V)>(
+        this, (id, v0), (a, b) => compare!(a.$1, b.$1));
+  }
+
+  /// Returns the `(ID, value)` pair for [id], or `null` if not found.
+  ///
+  /// Uses binary search and runs in `O(log n)`.
+  /// The list must be sorted by ID using [compare].
+  (D, V)? binarySearch(D id, [ComputeIDCompare<D>? compare]) {
+    var idx = binarySearchIndex(id, compare);
+    if (idx < 0) return null;
+    return this[idx];
+  }
+}
+
+/// Comparator used to order and compare IDs.
+typedef ComputeIDCompare<D> = int Function(D a, D b);
+
+/// Hash function used to compute a stable hash for an ID.
+typedef ComputeIDHash<D> = int Function(D e);
+
+/// An ordered, comparable, and hashable set of IDs.
+///
+/// IDs are copied and sorted on construction using [compare].
+/// Equality and hashing are based on the ordered ID list.
+class ComputeIDs<D extends Object> {
+  final List<D> _ids;
+
+  /// Unmodifiable view of the ordered IDs.
+  List<D> get ids => List.unmodifiable(_ids);
+
+  /// Comparator used to order and compare IDs.
+  final ComputeIDCompare<D>? compare;
+
+  /// Optional hash function used for hashCode computation.
+  final ComputeIDHash<D>? hash;
+
+  /// Creates a sorted ID collection.
+  ///
+  /// IDs are copied from [ids] and sorted using [compare].
+  ComputeIDs(List<D> ids, {ComputeIDCompare<D>? compare, this.hash})
+      : _ids = ids.toList(),
+        compare = _Comparer.resolveCompare(compare) {
+    _ids.sort(compare);
+  }
+
+  /// Number of IDs.
+  int get length => _ids.length;
+
+  /// Returns the ID at [index].
+  D operator [](int index) => _ids[index];
+
+  /// Returns the index of [value] using binary search, or `-1` if not found.
+  ///
+  /// Requires IDs to be sorted using [compare].
+  int binarySearchIndex(D value) =>
+      _Comparer.binarySearchIndex(_ids, value, compare);
+
+  /// Returns true if any of the provided [ids] exist in this collection.
+  bool containsAny(List<D> ids) {
+    final compare = this.compare;
+
+    if (compare != null) {
+      for (var id in ids) {
+        var idx = binarySearchIndex(id);
+        if (idx >= 0) return true;
+      }
+    } else {
+      for (var id1 in _ids) {
+        for (var id2 in ids) {
+          if (id1 == id2) return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /// Returns the intersection between this collection and [ids].
+  ///
+  /// Each entry is a pair of `(index, id)` where `index` refers to this
+  /// collection's internal ordering.
+  List<(int, D)> intersection(List<D> ids) {
+    var l = <(int, D)>[];
+
+    final compare = this.compare;
+
+    if (compare != null) {
+      for (var id in ids) {
+        var idx = binarySearchIndex(id);
+        if (idx >= 0) {
+          l.add((idx, id));
+        }
+      }
+    } else {
+      final length = _ids.length;
+      for (var i = 0; i < length; ++i) {
+        var id1 = _ids[i];
+        for (var id2 in ids) {
+          if (id1 == id2) {
+            l.add((i, id2));
+          }
+        }
+      }
+    }
+
+    return l;
+  }
+
+  /// Returns `(ID, value)` pairs for the given [indexes].
+  ///
+  /// [values] must be aligned with this collection's internal ordering.
+  List<(D, V)> getValuesByIndexes<V>(Iterable<int> indexes, List<V> values) {
+    return indexes.map((i) {
+      var id = _ids[i];
+      return (id, values[i]);
+    }).toList();
+  }
+
+  /// Returns true if [ids] are equal to this collection's IDs.
+  ///
+  /// Comparison respects [compare] when provided.
+  bool equalsIDs(List<D>? ids) {
+    if (ids == null) return false;
+
+    final length = _ids.length;
+    if (length != ids.length) return false;
+
+    final compare = this.compare;
+
+    if (compare != null) {
+      for (var i = 0; i < length; ++i) {
+        var id1 = _ids[i];
+        var id2 = ids[i];
+        if (compare(id1, id2) != 0) return false;
+      }
+    } else {
+      for (var i = 0; i < length; ++i) {
+        var id1 = _ids[i];
+        var id2 = ids[i];
+        if (id1 != id2) return false;
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ComputeIDs<D> &&
+          runtimeType == other.runtimeType &&
+          equalsIDs(other._ids);
+
+  int? _hashCode;
+
+  @override
+  int get hashCode => _hashCode ??= _Comparer.computeHashcode(_ids, hash);
+
+  @override
+  String toString() => 'ComputeIDs$_ids';
+}
+
+abstract class _Comparer {
+  static ComputeIDCompare<D>? resolveCompare<D>(ComputeIDCompare<D>? compare) {
+    if (compare != null) return compare;
+
+    if (D == int) {
+      return _cmpInt as ComputeIDCompare<D>;
+    } else if (D == double) {
+      return _cmpDouble as ComputeIDCompare<D>;
+    } else if (D == num) {
+      return _cmpNum as ComputeIDCompare<D>;
+    } else if (D == String) {
+      return _cmpString as ComputeIDCompare<D>;
+    }
+
+    return null;
+  }
+
+  static int _cmpInt(int a, int b) => a.compareTo(b);
+
+  static int _cmpDouble(double a, double b) => a.compareTo(b);
+
+  static int _cmpNum(num a, num b) => a.compareTo(b);
+
+  static int _cmpString(String a, String b) => a.compareTo(b);
+
+  static int _defaultCompare(Object a, Object b) {
+    if (a is Comparable && b is Comparable) {
+      return a.compareTo(b);
+    }
+    throw StateError(
+        'No comparator provided and elements are not Comparable: ${a.runtimeType} <=> ${b.runtimeType}');
+  }
+
+  static int binarySearchIndex<D extends Object>(List<D> ids, D value,
+      [ComputeIDCompare<D>? compare]) {
+    final cmp = compare ?? _defaultCompare;
+
+    int low = 0;
+    int high = ids.length - 1;
+
+    while (low <= high) {
+      final mid = (low + high) >> 1;
+      final c = cmp(ids[mid], value);
+
+      if (c < 0) {
+        low = mid + 1;
+      } else if (c > 0) {
+        high = mid - 1;
+      } else {
+        return mid;
+      }
+    }
+
+    return -1;
+  }
+
+  static const int _hashMask = 0x7fffffff;
+
+  static int computeHashcode<D extends Object>(
+      List<D>? list, ComputeIDHash<D>? hashFunction) {
+    if (list == null) return null.hashCode;
+
+    hashFunction ??= _defaultHash;
+
+    // Jenkins's one-at-a-time hash function.
+    // This code is almost identical to the one in IterableEquality, except
+    // that it uses indexing instead of iterating to get the elements.
+    var hash = 0;
+
+    for (var i = 0; i < list.length; i++) {
+      var c = hashFunction(list[i]);
+      hash = (hash + c) & _hashMask;
+      hash = (hash + (hash << 10)) & _hashMask;
+      hash ^= hash >> 6;
+    }
+
+    hash = (hash + (hash << 3)) & _hashMask;
+    hash ^= hash >> 11;
+    hash = (hash + (hash << 15)) & _hashMask;
+
+    return hash;
+  }
+
+  static int _defaultHash(Object e) => e.hashCode;
+}
+
+/// Utilities to resolve multiple [ComputeOnce] instances.
+extension IterableComputeOnceEtension<V> on Iterable<ComputeOnce<V>> {
+  /// Resolves all computations and returns their results in iteration order.
+  ///
+  /// If [throwError] is true, the first error is propagated.
+  /// Otherwise, [onError] or [onErrorValue] is used to produce a fallback value.
+  ///
+  /// The result may be returned synchronously or asynchronously.
+  FutureOr<List<V>> computeAll({
+    bool throwError = true,
+    FutureOr<V> Function(Object error, StackTrace stackTrace)? onError,
+    V? onErrorValue,
+  }) =>
+      map((e) => e.resolve(
+          throwError: throwError,
+          onError: onError,
+          onErrorValue: onErrorValue)).resolveAll();
+
+  /// Asynchronously resolves all computations and returns their results
+  /// in iteration order.
+  ///
+  /// Semantics are identical to [computeAll], but always returns a [Future].
+  Future<List<V>> computeAllAsync({
+    bool throwError = true,
+    Future<V> Function(Object error, StackTrace stackTrace)? onError,
+    V? onErrorValue,
+  }) =>
+      map((e) => e.resolveAsync(
+          throwError: throwError,
+          onError: onError,
+          onErrorValue: onErrorValue)).resolveAll();
+}
+
+/// Utilities to resolve all [TimedComputeOnce] values in a map keyed by
+/// [ComputeIDs].
+extension MapComputeIDsEtension<D extends Object, V>
+    on Map<ComputeIDs<D>, TimedComputeOnce<V>> {
+  /// Resolves all computations and returns a map with the same keys.
+  ///
+  /// If [throwError] is true, the first error is propagated.
+  /// Otherwise, [onError] or [onErrorValue] is used to produce a fallback value.
+  ///
+  /// The result may be returned synchronously or asynchronously.
+  FutureOr<Map<ComputeIDs<D>, V>> computeAll(
+          {bool throwError = true,
+          FutureOr<V> Function(Object error, StackTrace stackTrace)? onError,
+          V? onErrorValue}) =>
+      Map.fromEntries(
+        entries.map(
+          (e) => MapEntry(
+              e.key,
+              e.value.resolve(
+                  throwError: throwError,
+                  onError: onError,
+                  onErrorValue: onErrorValue)),
+        ),
+      ).resolveAllValues();
+
+  /// Asynchronously resolves all computations and returns a map with the
+  /// same keys.
+  ///
+  /// Semantics are identical to [computeAll], but always returns a [Future].
+  Future<Map<ComputeIDs<D>, V>> computeAllAsync(
+          {bool throwError = true,
+          Future<V> Function(Object error, StackTrace stackTrace)? onError,
+          V? onErrorValue}) =>
+      Map<ComputeIDs<D>, Future<V>>.fromEntries(
+        entries.map(
+          (e) => MapEntry(
+              e.key,
+              e.value.resolveAsync(
+                  throwError: throwError,
+                  onError: onError,
+                  onErrorValue: onErrorValue)),
+        ),
+      ).resolveAllValues().asFuture;
 }

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -715,6 +715,14 @@ class ComputeIDs<D extends Object> {
       : _ids = ids.toList(),
         compare = _Comparer.resolveCompare(compare) {
     _ids.sort(compare);
+
+    final cmp = this.compare ?? _Comparer._defaultCompare;
+    // Deduplicate (requires sorted list):
+    for (var i = _ids.length - 1; i > 0; --i) {
+      if (cmp(_ids[i], _ids[i - 1]) == 0) {
+        _ids.removeAt(i);
+      }
+    }
   }
 
   /// Number of IDs.

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -177,6 +177,7 @@ class ComputeOnce<V> {
         return _resolveFuture(future, throwError, onError, onErrorValue);
       } else {
         var value = call;
+
         if (posCompute != null) {
           try {
             var value2 = posCompute(value, null, null);
@@ -321,6 +322,7 @@ class ComputeOnce<V> {
         return future.catchError((e, s) => _castErrorValue(onErrorValue));
       }
     }
+
     return future;
   }
 

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -839,7 +839,7 @@ class ComputeIDs<D extends Object> {
   int get hashCode => _hashCode ??= _Comparer.computeHashcode(_ids, hash);
 
   @override
-  String toString() => 'ComputeIDs$_ids';
+  String toString() => 'ComputeIDs(${_ids.length})$_ids';
 }
 
 abstract class _Comparer {

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -318,7 +318,7 @@ class ComputeOnce<V> {
       if (onError != null) {
         return future.catchError(onError);
       } else {
-        return future.catchError((e, s) => onErrorValue as V);
+        return future.catchError((e, s) => _castErrorValue(onErrorValue));
       }
     }
     return future;

--- a/lib/src/async_extension_compute_once.dart
+++ b/lib/src/async_extension_compute_once.dart
@@ -565,11 +565,15 @@ class ComputeOnceCachedIDs<D extends Object, V>
     final idsNotCallingKey =
         ComputeIDs(idsNotCalling, compare: compare, hash: hash);
 
-    var computer = get(idsNotCallingKey, () => call(idsNotCallingKey.ids),
-        resolve: resolve);
+    var newComputer = get(
+      idsNotCallingKey,
+      () => call(idsNotCallingKey.ids),
+      posCompute: posCompute,
+      resolve: resolve,
+    );
 
     var computers = Map.fromEntries([
-      MapEntry(idsNotCallingKey, computer),
+      MapEntry(idsNotCallingKey, newComputer),
       ...calling,
     ]);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_extension
 description: Dart async extensions, to help usage of Future, FutureOr and async methods. Also allows performance improvements when using sync and async code.
-version: 1.2.19
+version: 1.2.20
 homepage: https://github.com/eneural-net/async_extension
 
 environment:

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -571,6 +571,25 @@ void main() {
 
     test('resolve(): async posCompute is applied synchronously', () async {
       final c = ComputeOnce<int>(
+        () => 1,
+        posCompute: (v, e, s) async => (v ?? 0) + 10,
+        resolve: false,
+      );
+
+      // resolve may return a value or a Future; normalize with Future.value(...)
+      final resultAsync = Future.value(c.resolve());
+
+      // subsequent resolves should return cached result (transformed)
+      final result2Async = Future.value(c.resolve());
+
+      var result = await resultAsync;
+      var result2 = await result2Async;
+      expect(result, equals(11));
+      expect(result2, equals(11));
+    });
+
+    test('resolve(): async posCompute is applied assynchronously', () async {
+      final c = ComputeOnce<int>(
         () async => Future.delayed(Duration(milliseconds: 60), () => 1),
         posCompute: (v, e, s) async => (v ?? 0) + 10,
         resolve: false,

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -554,7 +554,7 @@ void main() {
   });
 
   group('ComputeOnce posCompute', () {
-    test('sync posCompute is applied synchronously', () async {
+    test('resolve(): sync posCompute is applied synchronously', () async {
       final c = ComputeOnce<int>(
         () => 1,
         posCompute: (v, e, s) => (v ?? 0) + 10,
@@ -569,7 +569,38 @@ void main() {
       expect(result2, equals(11));
     });
 
-    test('async posCompute is applied asynchronously', () async {
+    test('resolve(): async posCompute is applied synchronously', () async {
+      final c = ComputeOnce<int>(
+        () async => 1,
+        posCompute: (v, e, s) async => (v ?? 0) + 10,
+      );
+
+      // resolve may return a value or a Future; normalize with Future.value(...)
+      final result = await Future.value(c.resolve());
+      expect(result, equals(11));
+
+      // subsequent resolves should return cached result (transformed)
+      final result2 = await Future.value(c.resolve());
+      expect(result2, equals(11));
+    });
+
+    test('resolveAsync(): sync posCompute is applied asynchronously', () async {
+      final c = ComputeOnce<int>(
+        () => 2,
+        posCompute: (v, e, s) => (v ?? 0) * 10,
+      );
+
+      // resolveAsync always returns a Future
+      final result = await c.resolveAsync();
+      expect(result, equals(20));
+
+      // subsequent resolves should return cached (transformed) result
+      final result2 = await c.resolveAsync();
+      expect(result2, equals(20));
+    });
+
+    test('resolveAsync(): async posCompute is applied asynchronously',
+        () async {
       final c = ComputeOnce<int>(
         () async => 2,
         posCompute: (v, e, s) async => (v ?? 0) * 10,

--- a/test/async_extension_compute_once_test.dart
+++ b/test/async_extension_compute_once_test.dart
@@ -571,16 +571,20 @@ void main() {
 
     test('resolve(): async posCompute is applied synchronously', () async {
       final c = ComputeOnce<int>(
-        () async => 1,
+        () async => Future.delayed(Duration(milliseconds: 60), () => 1),
         posCompute: (v, e, s) async => (v ?? 0) + 10,
+        resolve: false,
       );
 
       // resolve may return a value or a Future; normalize with Future.value(...)
-      final result = await Future.value(c.resolve());
-      expect(result, equals(11));
+      final resultAsync = Future.value(c.resolve());
 
       // subsequent resolves should return cached result (transformed)
-      final result2 = await Future.value(c.resolve());
+      final result2Async = Future.value(c.resolve());
+
+      var result = await resultAsync;
+      var result2 = await result2Async;
+      expect(result, equals(11));
       expect(result2, equals(11));
     });
 


### PR DESCRIPTION
- `ComputeOnce`:
  - Renamed `ComputeOnceCall` to `ComputeCall`.
  - Added `PosComputeCall` callback invoked after computation completes, receiving success or error results.
  - Added `posCompute` field to invoke post-computation callback.
  - Updated `resolve` and `resolveAsync` to apply `posCompute` on success or error.

- `TimedComputeOnce`:
  - Added support for `posCompute` callback.

- Added `ComputeOnceCache`:
  - Caches `TimedComputeOnce` instances by key.
  - Supports retention duration for cached entries with automatic eviction.
  - Provides `get` method to retrieve or create cached computations.

- Added `ComputeOnceCachedIDs`:
  - Extends `ComputeOnceCache` for batched computations by ID sets.
  - Supports ID ordering, hashing, and deduplication.
  - Shares in-flight computations for overlapping ID sets.
  - Provides `getByIDs` to get computations for subsets of IDs.
  - Provides `computeIDs` to compute and merge results for requested IDs, preserving order.

- Added `ComputeIDs`:
  - Represents an ordered, comparable, and hashable set of IDs.
  - Supports binary search, intersection, equality, and hashing.

- Added extensions:
  - `IterableComputeOnceEtension` for resolving multiple `ComputeOnce` instances.
  - `MapComputeIDsEtension` for resolving maps of `TimedComputeOnce` keyed by `ComputeIDs`.
  - `ListIdValuePairExtension` for binary searching `(ID, value)` pairs sorted by ID.

- Typedefs:
  - `ComputeCallIDs` for batched ID computations.
  - `ComputeIDCompare` and `ComputeIDHash` for ID comparison and hashing.